### PR TITLE
Add date argument to `log` command

### DIFF
--- a/lib/hcl/app.rb
+++ b/lib/hcl/app.rb
@@ -113,7 +113,7 @@ Commands:
     hcl stop [<message>]
 
     # log a task and time without leaving a timer running
-    hcl log @<task_alias> [+<time>] [<message>]
+    hcl log [<date>] @<task_alias> [+<time>] [<message>]
 
     # resume the last stopped timer or a specific task
     hcl resume [@<task_alias>]

--- a/lib/hcl/commands.rb
+++ b/lib/hcl/commands.rb
@@ -118,9 +118,16 @@ module HCl
     end
 
     def log *args
-      fail "There is already a timer running." if DayEntry.with_timer(http)
-      start *args
-      stop
+      date = get_date(args)
+      starting_time = get_starting_time args
+      task = get_task args
+      if task.nil?
+        fail "Unknown task alias, try one of the following: ", aliases.join(', ')
+      end
+      timer = task.add http,
+        :spent_at => date,
+        :starting_time => starting_time,
+        :note => args.join(' ')
     end
 
     def stop *args

--- a/lib/hcl/task.rb
+++ b/lib/hcl/task.rb
@@ -50,12 +50,13 @@ module HCl
     def add http, opts
       notes = opts[:note]
       starting_time = opts[:starting_time] || 0
+      spent_at = opts[:spent_at] || Date.today
       DayEntry.new http.post("daily/add", {
         notes: notes,
         hours: starting_time,
         project_id: project.id,
         task_id: id,
-        spent_at: Date.today
+        spent_at: spent_at
       })
     end
 

--- a/lib/hcl/utility.rb
+++ b/lib/hcl/utility.rb
@@ -1,3 +1,5 @@
+require 'chronic'
+
 module HCl
   class CommandError < StandardError; end
   module Utility
@@ -32,6 +34,14 @@ module HCl
       if starting_time
         args.delete(starting_time)
         time2float starting_time
+      end
+    end
+
+    def get_date args
+      ident_index = args.index {|a| a[0] == '@' }
+
+      unless ident_index.nil?
+        Chronic.parse(args.shift(ident_index).join(' '))
       end
     end
 

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -31,11 +31,6 @@ class CommandTest < HCl::TestCase
     assert_equal "taco.time: now\n", standard_output
   end
 
-  def test_log_failure
-    HCl::DayEntry.expects(:with_timer).returns(stub)
-    assert_raises(HCl::CommandError) { log "stuff" }
-  end
-
   def test_tasks
     FileUtils.rm_rf ENV['HCL_DIR']+"/cache"
     register_uri(:get, '/daily', {:day_entries=>[], :projects=> [{

--- a/test/utility_test.rb
+++ b/test/utility_test.rb
@@ -24,6 +24,14 @@ class UtilityTest < HCl::TestCase
     assert_equal 0.25, get_starting_time(%w[ @taco +.25 makin tacos ])
   end
 
+  def test_get_date_without_ident
+    assert_nil get_date(%w[ yesterday +2 no task ])
+  end
+
+  def test_get_date_with_ident
+    assert_equal Chronic.parse('2018-01-15'), get_date(%w[ january 15 2018 @taco +.30 makin tacos ])
+  end
+
   def test_time2float_decimal
     assert_equal 2.5, time2float("2.5")
   end


### PR DESCRIPTION
Adds an optional date argument to the `log` command that can be
specified just before the task alias.

Some examples from @skoppelmanCC:

    hcl log yesterday @documentation +2 Ran spellcheck
    hcl log 3 days ago @wireframes +3.5
    hcl log last friday @admin +1 filed timesheets

Commands#log:
Copy over the contents of `Commands#start` and replace `task.start` with
`task.add`. This allows us to log the time without actually starting a
timer (and thus having to subsequently stop that timer).

command_test.rb(#test_start):
Update expected method call arguments with `spent_at`. Now that we're
passing in `spent_at`, the expected arguments should include it.

command_test.rb(#test_log_failure):
Delete this test because I've rewritten the `Commands#log` method to no
longer use timers.

utility_test.rb: Add tests for `#get_date`

Fixes #83.